### PR TITLE
Tweaked grammar and removed license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,10 @@
 SimulatorManager
 ================
 
-Simple Mac Application to perform quick access iOS Simulator Application data
+A Simple Mac Application to quickly access iOS Simulator Application data
 
-This app only support Xcode 6
+This app only supports Xcode 6
 
 ![Screen Shot](/Screenshot/1.png?raw=true "Screen Shot")
 
-The MIT License (MIT)
-================
 
-Copyright (c) 2014 Pharaoh
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.


### PR DESCRIPTION
Slightly reworded description so it makes more grammatical sense.

Also removed duplicate license information.
